### PR TITLE
Add reconnect options and integration test for NATSClient

### DIFF
--- a/Sources/NATS/NATS.swift
+++ b/Sources/NATS/NATS.swift
@@ -32,10 +32,11 @@ public final class NATSClient: Service, @unchecked Sendable {
     private func makeOptions() -> NATSOptionsHandle {
         let opts = NATSOptionsHandle()
         opts.setURL(configuration.url)
-        // Reconnect options
-        // opts.setReconnect(configuration.reconnect)
-        // opts.setMaxReconnects(configuration.maxReconnects)
-        // opts.setReconnectWait(configuration.reconnectWait)
+        if configuration.reconnect {
+            opts.setAllowReconnect(true)
+            opts.setMaxReconnects(configuration.maxReconnects)
+            opts.setReconnectWait(configuration.reconnectWait)
+        }
         // Auth
         switch configuration.auth {
         case .none:

--- a/Sources/NATSCore/NATSOptionsHandle.swift
+++ b/Sources/NATSCore/NATSOptionsHandle.swift
@@ -6,6 +6,7 @@
 //
 
 import CNATS
+import Foundation
 
 /// Handle for NATS options. Wraps the underlying C pointer and provides methods to set various options.
 public final class NATSOptionsHandle {
@@ -50,5 +51,18 @@ public final class NATSOptionsHandle {
     
     public func setUserCredentialsFile(_ file: String) {
         natsOptions_SetUserCredentialsFromFiles(ptr, file, nil)
+    }
+
+    public func setAllowReconnect(_ allow: Bool) {
+        natsOptions_SetAllowReconnect(ptr, allow)
+    }
+
+    public func setMaxReconnects(_ max: Int) {
+        natsOptions_SetMaxReconnect(ptr, Int32(max))
+    }
+
+    public func setReconnectWait(_ seconds: TimeInterval) {
+        let ms = Int64(seconds * 1000)
+        natsOptions_SetReconnectWait(ptr, ms)
     }
 }

--- a/Tests/IntegrationTests/IntegrationTests.swift
+++ b/Tests/IntegrationTests/IntegrationTests.swift
@@ -4,83 +4,110 @@ import ServiceLifecycle
 import Logging
 @testable import NATS
 
-final class IntegrationTests {
-    static let logger = Logger(label: "NATSClientTests")
-    
-    let client: NATSClient
-    let group: ServiceGroup
-    var runTask: Task<Void, Error>?
-    
-    init() async throws {
-        self.client = NATSClient(
-            configuration: .init(auth: .userPassword(user: "app", password: "app")),
-            logger: Self.logger
-        )
-        
-        self.group = ServiceGroup(configuration: .init(services: [client], logger: Self.logger))
-        self.runTask = Task { try await self.group.run() }
+enum TestError: Error {
+    case connectionFailed
+}
 
-        for _ in 0..<50 {
-            if await client.connectionState == .connected {
-                break
-            }
-            try await Task.sleep(nanoseconds: 50_000_000) // 50ms
+let testLogger = Logger(label: "NATSClientTests")
+
+func startServer() throws -> Process {
+    let process = Process()
+    let path = ProcessInfo.processInfo.environment["NATS_SERVER"] ?? "/usr/local/bin/nats-server"
+    process.executableURL = URL(fileURLWithPath: path)
+    process.arguments = ["-p", "4222"]
+    process.standardOutput = nil
+    process.standardError = nil
+    try process.run()
+    Thread.sleep(forTimeInterval: 0.5)
+    return process
+}
+
+func waitForConnection(_ client: NATSClient) async throws {
+    for _ in 0..<50 {
+        if await client.connectionState == .connected {
+            return
         }
+        try await Task.sleep(nanoseconds: 50_000_000)
+    }
+    throw TestError.connectionFailed
+}
+
+@Test
+func testNATSClientConnectAndShutdown() async throws {
+    let server = try startServer()
+    defer {
+        server.terminate()
+        try? server.waitUntilExit()
     }
 
-    @Test
-    func testNATSClientConnectAndShutdown() async throws {
-        try await withThrowingTaskGroup(of: Void.self) { taskGroup in
-            
-            if let runTask = self.runTask {
-                taskGroup.addTask {
-                    try await runTask.value
-                }
-            }
-            // Test logic (just connect, wait, shutdown)
-            taskGroup.addTask {
-                try await Task.sleep(for: .seconds(1))
-                await self.group.triggerGracefulShutdown()
-            }
-            // Wait for all
-            try await taskGroup.next()
-            try await taskGroup.next()
-        }
+    let client = NATSClient(configuration: .init(), logger: testLogger)
+    let group = ServiceGroup(configuration: .init(services: [client], logger: testLogger))
+    let runTask = Task { try await group.run() }
+    try await waitForConnection(client)
+    await group.triggerGracefulShutdown()
+    try await runTask.value
+}
+
+@Test
+func testNATSClientPublishSubscribe() async throws {
+    let server = try startServer()
+    defer {
+        server.terminate()
+        try? server.waitUntilExit()
     }
 
-    @Test
-    func testNATSClientPublishSubscribe() async throws {
-        try await withThrowingTaskGroup(of: Void.self) { taskGroup in
+    let client = NATSClient(configuration: .init(), logger: testLogger)
+    let group = ServiceGroup(configuration: .init(services: [client], logger: testLogger))
+    let runTask = Task { try await group.run() }
+    try await waitForConnection(client)
 
-            if let runTask = self.runTask {
-                taskGroup.addTask {
-                    try await runTask.value
-                }
-            }
-            
-            // Publisher/Subscriber logic
-            taskGroup.addTask {
-                let subject = "test.natsclient.pubsub", data = "hello highlevel".data(using: .utf8)!
-                let stream = self.client.subscribe(subject: subject)
-                var received = false
-                let subTask = Task {
-                    for await msg in stream {
-                        print("Received message on \(msg.subject): \(String(data: msg.data, encoding: .utf8) ?? "nil")")
-                        #expect(msg.subject == subject)
-                        #expect(msg.data == data)
-                        received = true
-                        break
-                    }
-                }
-                try await self.client.publish(subject: subject, data: data)
-                // Чекаємо завершення підписки (отримання повідомлення)
-                while !received {
-                    await Task.yield()
-                }
-                subTask.cancel()
-            }
-            try await taskGroup.next()
-            await self.group.triggerGracefulShutdown()
+    let subject = "test.natsclient.pubsub"
+    let data = "hello highlevel".data(using: .utf8)!
+    let stream = client.subscribe(subject: subject)
+    var received = false
+    let subTask = Task {
+        for await msg in stream {
+            #expect(msg.subject == subject)
+            #expect(msg.data == data)
+            received = true
+            break
         }
     }
+    try await client.publish(subject: subject, data: data)
+    while !received { await Task.yield() }
+    subTask.cancel()
+
+    await group.triggerGracefulShutdown()
+    try await runTask.value
+}
+
+@Test
+func testReconnectAfterServerRestart() async throws {
+    var server = try startServer()
+    defer {
+        server.terminate()
+        try? server.waitUntilExit()
+    }
+
+    let config = NATSClientConfiguration(reconnect: true, maxReconnects: 10, reconnectWait: 0.5)
+    let client = NATSClient(configuration: config, logger: testLogger)
+    let group = ServiceGroup(configuration: .init(services: [client], logger: testLogger))
+    let runTask = Task { try await group.run() }
+    try await waitForConnection(client)
+
+    server.terminate()
+    try? server.waitUntilExit()
+
+    server = try startServer()
+
+    for _ in 0..<100 {
+        if await client.connectionState == .connected {
+            break
+        }
+        try await Task.sleep(nanoseconds: 100_000_000)
+    }
+    #expect(await client.connectionState == .connected)
+
+    await group.triggerGracefulShutdown()
+    try await runTask.value
 }


### PR DESCRIPTION
## Summary
- expose reconnect-related setters on `NATSOptionsHandle`
- apply reconnect options in `NATSClient.makeOptions`
- add integration tests that verify connection, pub/sub, and reconnection after server restart

## Testing
- `swift test -q`


------
https://chatgpt.com/codex/tasks/task_e_68ba5adaaf008330abc0aece4be6d0e2