### PR TITLE
Add NKey authentication support

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -19,6 +19,15 @@
       }
     },
     {
+      "identity" : "swift-crypto",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-crypto",
+      "state" : {
+        "revision" : "60f13f60c4d093691934dc6cfdf5f508ada1f894",
+        "version" : "2.6.0"
+      }
+    },
+    {
       "identity" : "swift-log",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-log",

--- a/Package.swift
+++ b/Package.swift
@@ -15,7 +15,8 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/apple/swift-log", from: "1.1.0"),
         .package(url: "https://github.com/apple/swift-metrics", from: "2.5.0"),
-        .package(url: "https://github.com/swift-server/swift-service-lifecycle", from: "2.1.0")
+        .package(url: "https://github.com/swift-server/swift-service-lifecycle", from: "2.1.0"),
+        .package(url: "https://github.com/apple/swift-crypto", from: "2.4.0")
     ],
     targets: [
         // Targets are the basic building blocks of a package, defining a module or a test suite.
@@ -64,7 +65,8 @@ let package = Package(
             dependencies: [
                 "CNATS",
                 .product(name: "Logging", package: "swift-log"),
-                .product(name: "Metrics", package: "swift-metrics")
+                .product(name: "Metrics", package: "swift-metrics"),
+                .product(name: "Crypto", package: "swift-crypto")
             ]
         ),
         // 3. High-level async/await API + ServiceLifecycle

--- a/Sources/NATS/NATS.swift
+++ b/Sources/NATS/NATS.swift
@@ -44,9 +44,8 @@ public final class NATSClient: Service, @unchecked Sendable {
             opts.setUserInfo(user: user, password: password)
         case .token(let token):
             opts.setToken(token)
-        case .nkey:
-            // NKey підтримується лише через creds-файл (JWT+NKey)
-            break // Для простоти, не підтримуємо окремо seed
+        case .nkey(let seed):
+            opts.setNKey(seed: seed)
         case .jwtCredsFile(let file):
             opts.setUserCredentialsFile(file)
         }

--- a/Sources/NATSCore/NATSOptionsHandle.swift
+++ b/Sources/NATSCore/NATSOptionsHandle.swift
@@ -6,6 +6,7 @@
 //
 
 import CNATS
+import Crypto
 
 /// Handle for NATS options. Wraps the underlying C pointer and provides methods to set various options.
 public final class NATSOptionsHandle {
@@ -47,8 +48,82 @@ public final class NATSOptionsHandle {
     public func setToken(_ token: String) {
         natsOptions_SetToken(ptr, token)
     }
-    
+
     public func setUserCredentialsFile(_ file: String) {
         natsOptions_SetUserCredentialsFromFiles(ptr, file, nil)
     }
+
+    /// Configure NKey authentication using an encoded seed.
+    public func setNKey(seed: String) {
+        guard let pub = NKeyUtilities.publicKey(fromSeed: seed) else { return }
+        let seedPtr = strdup(seed)
+        let cb: NATSSignatureHandler = { _, sigPtr, sigLenPtr, nonce, closure in
+            guard let nonce, let closure else { return NATS_INVALID_ARG }
+            let seed = closure.assumingMemoryBound(to: CChar.self)
+            var sig: UnsafeMutablePointer<UInt8>? = nil
+            var sigLen: Int32 = 0
+            let s = nats_Sign(seed, nonce, &sig, &sigLen)
+            if s == NATS_OK {
+                sigPtr?.pointee = sig
+                sigLenPtr?.pointee = sigLen
+            }
+            return s
+        }
+        natsOptions_SetNKey(ptr, pub, cb, UnsafeMutableRawPointer(seedPtr))
+    }
 }
+
+// MARK: - NKey helpers
+
+enum NKeyUtilities {
+    static func publicKey(fromSeed seed: String) -> String? {
+        let maxLen = Int(Double(seed.count) * 5.0 / 8.0) + 10
+        var raw = [Int8](repeating: 0, count: maxLen)
+        var rawLen: Int32 = 0
+        seed.withCString { src in
+            raw.withUnsafeMutableBufferPointer { ptr in
+                _ = nats_Base32_DecodeString(src, ptr.baseAddress, Int32(maxLen), &rawLen)
+            }
+        }
+        if rawLen < 36 { return nil }
+        let seedBytes: [UInt8] = raw.withUnsafeBufferPointer { buf in
+            let base = buf.baseAddress!
+            return (0..<Int(rawLen)).map { UInt8(bitPattern: base[$0]) }
+        }
+        let prefix = seedBytes[1]
+        let priv = Array(seedBytes[2..<(2+32)])
+        guard let sk = try? Curve25519.Signing.PrivateKey(rawRepresentation: priv) else { return nil }
+        var pubData = [UInt8]()
+        pubData.append(prefix)
+        pubData.append(contentsOf: sk.publicKey.rawRepresentation)
+        let crc = pubData.withUnsafeMutableBufferPointer { ptr in
+            nats_CRC16_Compute(ptr.baseAddress, Int32(ptr.count))
+        }
+        pubData.append(UInt8(crc & 0xff))
+        pubData.append(UInt8((crc >> 8) & 0xff))
+        return base32Encode(pubData)
+    }
+
+    private static let alphabet: [Character] = Array("ABCDEFGHIJKLMNOPQRSTUVWXYZ234567")
+
+    private static func base32Encode(_ bytes: [UInt8]) -> String {
+        var output = ""
+        var buffer: Int = 0
+        var bitsLeft: Int = 0
+        for b in bytes {
+            buffer = (buffer << 8) | Int(b)
+            bitsLeft += 8
+            while bitsLeft >= 5 {
+                let index = (buffer >> (bitsLeft - 5)) & 0x1F
+                output.append(alphabet[index])
+                bitsLeft -= 5
+            }
+        }
+        if bitsLeft > 0 {
+            let index = (buffer << (5 - bitsLeft)) & 0x1F
+            output.append(alphabet[index])
+        }
+        return output
+    }
+}
+

--- a/Tests/IntegrationTests/IntegrationTests.swift
+++ b/Tests/IntegrationTests/IntegrationTests.swift
@@ -84,3 +84,46 @@ final class IntegrationTests {
         }
     }
 }
+
+final class NKeyIntegrationTests {
+    static let logger = Logger(label: "NATSNKeyTests")
+
+    @Test
+    func testNKeyAuth() async throws {
+        let pair = try generateNKeyPair()
+        let proc = Process()
+        proc.executableURL = URL(fileURLWithPath: "/usr/local/bin/nats-server")
+        proc.arguments = ["--port", "4223", "--nkey", pair.pub]
+        try proc.run()
+        defer { proc.terminate() }
+
+        try await Task.sleep(nanoseconds: 500_000_000)
+
+        let client = NATSClient(configuration: .init(url: "nats://127.0.0.1:4223", auth: .nkey(seed: pair.seed)), logger: Self.logger)
+        let group = ServiceGroup(configuration: .init(services: [client], logger: Self.logger))
+        let runTask = Task { try await group.run() }
+
+        for _ in 0..<50 {
+            if await client.connectionState == .connected { break }
+            try await Task.sleep(nanoseconds: 50_000_000)
+        }
+        #expect(await client.connectionState == .connected)
+        await group.triggerGracefulShutdown()
+        try await runTask.value
+    }
+
+    private func generateNKeyPair() throws -> (seed: String, pub: String) {
+        let proc = Process()
+        proc.executableURL = URL(fileURLWithPath: "/usr/bin/env")
+        proc.arguments = ["nk", "-gen", "user", "-pubout"]
+        let pipe = Pipe()
+        proc.standardOutput = pipe
+        try proc.run()
+        proc.waitUntilExit()
+        let data = pipe.fileHandleForReading.readDataToEndOfFile()
+        let lines = String(data: data, encoding: .utf8)?.split(separator: "\n") ?? []
+        let seed = String(lines.first ?? "")
+        let pub = String(lines.dropFirst().first ?? "")
+        return (seed, pub)
+    }
+}


### PR DESCRIPTION
## Summary
- wrap CNATS `natsOptions_SetNKey` with Swift helper and utilities
- handle `.nkey(seed:)` auth mode in `NATSClient.makeOptions`
- add NKey integration test and crypto dependency

## Testing
- `swift test` *(fails: header '../nats.c/src/nats.h' not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ba5ad048e08330b8570b9570a776ce